### PR TITLE
Transform QuickCheck code into `Arbitrary` instances

### DIFF
--- a/src/Proto3/Suite/DotProto/AST.hs
+++ b/src/Proto3/Suite/DotProto/AST.hs
@@ -1,11 +1,37 @@
 -- | Fairly straightforward AST encoding of the .proto grammar
 
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
 
-module Proto3.Suite.DotProto.AST where
+module Proto3.Suite.DotProto.AST
+  ( -- * Types
+      MessageName(..)
+    , FieldName(..)
+    , PackageName(..)
+    , DotProtoIdentifier(..)
+    , DotProtoImport(..)
+    , DotProtoImportQualifier(..)
+    , DotProtoPackageSpec(..)
+    , DotProtoOption(..)
+    , DotProtoDefinition(..)
+    , DotProto(..)
+    , DotProtoValue(..)
+    , DotProtoPrimType(..)
+    , Packing(..)
+    , DotProtoType(..)
+    , DotProtoEnumValue
+    , DotProtoEnumPart(..)
+    , Streaming(..)
+    , DotProtoServicePart(..)
+    , DotProtoMessagePart(..)
+    , DotProtoField(..)
+    , DotProtoReservedField(..)
+
+    -- * Utilities
+    , isPackableType
+  ) where
 
 import           Data.String        (IsString)
-import           Control.Monad
 import           Numeric.Natural
 import           Proto3.Wire.Types  (FieldNumber (..))
 import           Test.QuickCheck
@@ -47,11 +73,24 @@ data DotProtoImport = DotProtoImport
   , dotProtoImportPath      :: String
   } deriving (Show, Eq)
 
+instance Arbitrary DotProtoImport where
+    arbitrary = do
+      dotProtoImportQualifier <- arbitrary
+      let dotProtoImportPath = ""
+      return (DotProtoImport {..})
+
 data DotProtoImportQualifier
   = DotProtoImportPublic
   | DotProtoImportWeak
   | DotProtoImportDefault
   deriving (Show, Eq)
+
+instance Arbitrary DotProtoImportQualifier where
+  arbitrary = elements
+    [ DotProtoImportDefault
+    , DotProtoImportWeak
+    , DotProtoImportPublic
+    ]
 
 -- | The namespace declaration
 data DotProtoPackageSpec
@@ -59,8 +98,27 @@ data DotProtoPackageSpec
   | DotProtoNoPackage
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoPackageSpec where
+  arbitrary = oneof
+    [ return DotProtoNoPackage
+    , fmap DotProtoPackageSpec arbitrarySingleIdentifier
+    , fmap DotProtoPackageSpec arbitraryPathIdentifier
+    ]
+
 -- | An option id/value pair, can be attached to many types of statements
-data DotProtoOption = DotProtoOption DotProtoIdentifier DotProtoValue deriving (Show, Eq)
+data DotProtoOption = DotProtoOption
+  { dotProtoOptionIdentifier :: DotProtoIdentifier
+  , dotProtoOptionValue      :: DotProtoValue
+  } deriving (Show, Eq)
+
+instance Arbitrary DotProtoOption where
+    arbitrary = do
+      dotProtoOptionIdentifier <- oneof
+        [ arbitraryPathIdentifier
+        , arbitraryNestedIdentifier
+        ]
+      dotProtoOptionValue <- arbitrary
+      return (DotProtoOption {..})
 
 -- | Top-level protocol definitions
 data DotProtoDefinition
@@ -69,6 +127,19 @@ data DotProtoDefinition
   | DotProtoService DotProtoIdentifier [DotProtoServicePart]
   | DotProtoNullDef
   deriving (Show, Eq)
+
+instance Arbitrary DotProtoDefinition where
+  arbitrary = oneof [arbitraryMessage, arbitraryEnum]
+    where
+      arbitraryMessage = do
+        identifier <- arbitrarySingleIdentifier
+        parts      <- smallListOf arbitrary
+        return (DotProtoMessage identifier parts)
+
+      arbitraryEnum = do
+        identifier <- arbitrarySingleIdentifier
+        parts      <- smallListOf arbitrary
+        return (DotProtoEnum identifier parts)
 
 -- | This data structure represents a .proto file
 --   The actual source order of protobuf statements isn't meaningful so statements are sorted by type during parsing
@@ -80,6 +151,14 @@ data DotProto = DotProto
   , protoDefinitions :: [DotProtoDefinition]
   } deriving (Show, Eq)
 
+instance Arbitrary DotProto where
+  arbitrary = do
+    protoImports     <- smallListOf arbitrary
+    protoOptions     <- smallListOf arbitrary
+    protoPackage     <- arbitrary
+    protoDefinitions <- smallListOf arbitrary
+    return (DotProto {..})
+
 -- | Matches the definition of `constant` in the proto3 language spec
 --   These are only used as rvalues
 data DotProtoValue
@@ -89,6 +168,15 @@ data DotProtoValue
   | FloatLit   Double
   | BoolLit    Bool
   deriving (Show, Eq)
+
+instance Arbitrary DotProtoValue where
+  arbitrary = oneof
+    [ fmap Identifier  arbitrarySingleIdentifier
+    , fmap StringLit  (return "")
+    , fmap IntLit      arbitrary
+    , fmap FloatLit    arbitrary
+    , fmap BoolLit     arbitrary
+    ]
 
 data DotProtoPrimType
   = Int32
@@ -109,10 +197,35 @@ data DotProtoPrimType
   | Named DotProtoIdentifier -- ^ A named type, referring to another message or enum defined in the same file
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoPrimType where
+  arbitrary = oneof
+    [ elements
+      [ Int32
+      , Int64
+      , SInt32
+      , SInt64
+      , UInt32
+      , UInt64
+      , Fixed32
+      , Fixed64
+      , SFixed32
+      , SFixed64
+      , String
+      , Bytes
+      , Bool
+      , Float
+      , Double
+      ]
+    , fmap Named arbitrarySingleIdentifier
+    ]
+
 data Packing
   = PackedField
   | UnpackedField
   deriving (Show, Eq)
+
+instance Arbitrary Packing where
+  arbitrary = elements [PackedField, UnpackedField]
 
 -- | This type is an almagamation of the modifiers used in types
 --   It corresponds to a syntax role but not a semantic role, not all modifiers are meaningful in every type context
@@ -124,6 +237,9 @@ data DotProtoType
   | Map            DotProtoPrimType DotProtoPrimType
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoType where
+  arbitrary = oneof [fmap Prim arbitrary]
+
 type DotProtoEnumValue = Int
 
 data DotProtoEnumPart
@@ -132,10 +248,25 @@ data DotProtoEnumPart
   | DotProtoEnumEmpty
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoEnumPart where
+  arbitrary = oneof [arbitraryField, arbitraryOption]
+    where
+      arbitraryField = do
+        identifier <- arbitraryIdentifier
+        enumValue  <- arbitrary
+        return (DotProtoEnumField identifier enumValue)
+
+      arbitraryOption = do
+        option <- arbitrary
+        return (DotProtoEnumOption option)
+
 data Streaming
   = Streaming
   | NonStreaming
   deriving (Show, Eq)
+
+instance Arbitrary Streaming where
+  arbitrary = elements [Streaming, NonStreaming]
 
 -- [refactor] add named accessors to ServiceRPC
 --            break this into two types
@@ -144,6 +275,28 @@ data DotProtoServicePart
   | DotProtoServiceOption DotProtoOption
   | DotProtoServiceEmpty
   deriving (Show, Eq)
+
+instance Arbitrary DotProtoServicePart where
+  arbitrary = oneof
+    [ arbitraryServiceRPC
+    , arbitraryServiceOption
+    ]
+    where
+      arbitraryServiceRPC = do
+        identifier <- arbitrarySingleIdentifier
+        rpcClause0 <- arbitraryRPCClause
+        rpcClause1 <- arbitraryRPCClause
+        options    <- smallListOf arbitrary
+        return (DotProtoServiceRPC identifier rpcClause0 rpcClause1 options)
+        where
+          arbitraryRPCClause = do
+            identifier <- arbitraryIdentifier
+            streaming  <- arbitrary
+            return (identifier, streaming)
+
+      arbitraryServiceOption = do
+        option <- arbitrary
+        return (DotProtoServiceOption option)
 
 data DotProtoMessagePart
   = DotProtoMessageField DotProtoField
@@ -155,6 +308,34 @@ data DotProtoMessagePart
   | DotProtoMessageReserved   [DotProtoReservedField]
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoMessagePart where
+  arbitrary = oneof
+    [ arbitraryField
+    , arbitraryOneOf
+    , arbitraryDefinition
+    , arbitraryReserved
+    ]
+    where
+      arbitraryField = do
+        field <- arbitrary
+        return (DotProtoMessageField field)
+
+      arbitraryOneOf = do
+        dotProtoOneOfName   <- arbitrarySingleIdentifier
+        dotProtoOneOfFields <- smallListOf arbitrary
+        return (DotProtoMessageOneOf {..})
+
+      arbitraryDefinition = do
+        definition <- arbitrary
+        return (DotProtoMessageDefinition definition)
+
+      arbitraryReserved = do
+        fields <- oneof [smallListOf1 arbitrary, arbitraryReservedLabels]
+        return (DotProtoMessageReserved fields)
+
+      arbitraryReservedLabels :: Gen [DotProtoReservedField]
+      arbitraryReservedLabels = smallListOf1 (ReservedIdentifier <$> return "")
+
 data DotProtoField = DotProtoField
   { dotProtoFieldNumber  :: FieldNumber
   , dotProtoFieldType    :: DotProtoType
@@ -165,11 +346,38 @@ data DotProtoField = DotProtoField
   | DotProtoEmptyField
   deriving (Show, Eq)
 
+instance Arbitrary DotProtoField where
+  arbitrary = do
+    dotProtoFieldNumber  <- arbitrary
+    dotProtoFieldType    <- arbitrary
+    dotProtoFieldName    <- arbitraryIdentifier
+    dotProtoFieldOptions <- smallListOf arbitrary
+    -- TODO: Generate random comments once the parser supports comments
+    dotProtoFieldComment <- pure Nothing
+    return (DotProtoField {..})
+
 data DotProtoReservedField
   = SingleField Int
   | FieldRange  Int Int
   | ReservedIdentifier String
   deriving (Show, Eq)
+
+instance Arbitrary DotProtoReservedField where
+  arbitrary =
+    oneof [arbitrarySingleField, arbitraryFieldRange]
+      where
+        arbitraryFieldNumber = do
+          natural <- arbitrary
+          return (fromIntegral (natural :: Natural))
+
+        arbitrarySingleField = do
+          fieldNumber <- arbitraryFieldNumber
+          return (SingleField fieldNumber)
+
+        arbitraryFieldRange = do
+          begin <- arbitraryFieldNumber
+          end   <- arbitraryFieldNumber
+          return (FieldRange begin end)
 
 -- | Returns 'True' if the given primitive type is packable
 isPackableType :: DotProtoPrimType -> Bool
@@ -193,116 +401,36 @@ isPackableType Double = True
 --------------------------------------------------------------------------------
 -- | QC Arbitrary instance for generating random protobuf
 
-instance Arbitrary DotProto where
-  arbitrary = DotProto <$> smallListOf arbitraryImport <*> smallListOf arbitraryOption <*> arbitraryPackageSpec <*> smallListOf arbitraryDefinition
-
-arbitraryImport :: Gen DotProtoImport
-arbitraryImport = DotProtoImport <$> elements [DotProtoImportDefault, DotProtoImportWeak, DotProtoImportPublic]
-                                 <*> return "" -- arbitrary
-
-arbitraryOption :: Gen DotProtoOption
-arbitraryOption = DotProtoOption <$> oneof [arbitraryPathIdentifier, arbitraryNestedIdentifier] <*> arbitraryValue
-
-arbitraryPackageSpec :: Gen DotProtoPackageSpec
-arbitraryPackageSpec = oneof [ return DotProtoNoPackage
-                             , DotProtoPackageSpec <$> arbitrarySingleIdentifier
-                             , DotProtoPackageSpec <$> arbitraryPathIdentifier
-                             ]
-
-arbitraryDefinition :: Gen DotProtoDefinition
-arbitraryDefinition = oneof [ arbitraryMessage
-                            , arbitraryEnum
-                            ]
-
-arbitraryMessage :: Gen DotProtoDefinition
-arbitraryMessage = DotProtoMessage <$> arbitrarySingleIdentifier <*> smallListOf arbitraryMessagePart
-
-arbitraryMessagePart :: Gen DotProtoMessagePart
-arbitraryMessagePart = oneof [ DotProtoMessageField      <$> arbitraryField
-                             , DotProtoMessageOneOf      <$> arbitrarySingleIdentifier <*> smallListOf arbitraryField
-                             , DotProtoMessageDefinition <$> arbitraryDefinition
-                             , DotProtoMessageReserved   <$> oneof [arbitraryReservedNumbers, arbitraryReservedLabels]
-                             ]
-
-arbitraryReservedNumbers :: Gen [DotProtoReservedField]
-arbitraryReservedNumbers = smallListOf1 $ oneof [SingleField <$> arbitraryFieldNumber, FieldRange <$> arbitraryFieldNumber <*> arbitraryFieldNumber]
-
-arbitraryReservedLabels :: Gen [DotProtoReservedField]
-arbitraryReservedLabels = smallListOf1 $ ReservedIdentifier <$> return "" -- arbitrary
-
-arbitraryEnum :: Gen DotProtoDefinition
-arbitraryEnum = DotProtoEnum <$> arbitrarySingleIdentifier <*> smallListOf arbitraryEnumPart
-
-arbitraryEnumPart :: Gen DotProtoEnumPart
-arbitraryEnumPart = oneof [ DotProtoEnumField <$> arbitraryIdentifier <*> arbitrary
-                          , DotProtoEnumOption <$> arbitraryOption
-                          ]
-
 arbitraryService :: Gen DotProtoDefinition
-arbitraryService = DotProtoService <$> arbitrarySingleIdentifier <*> smallListOf arbitraryServicePart
-
-arbitraryServicePart :: Gen DotProtoServicePart
-arbitraryServicePart = oneof [ DotProtoServiceRPC <$> arbitrarySingleIdentifier <*> arbitraryRPCClause <*> arbitraryRPCClause <*> smallListOf arbitraryOption
-                             , DotProtoServiceOption <$> arbitraryOption
-                             ]
-
-arbitraryRPCClause :: Gen (DotProtoIdentifier, Streaming)
-arbitraryRPCClause = (,) <$> arbitraryIdentifier <*> elements [Streaming, NonStreaming]
-
--- TODO: Generate random comments once the parser supports comments
-arbitraryField :: Gen DotProtoField
-arbitraryField = DotProtoField <$> arbitrary <*> arbitraryType <*> arbitraryIdentifier <*> smallListOf arbitraryOption <*> pure Nothing
-
-arbitraryType :: Gen DotProtoType
-arbitraryType = oneof [ Prim <$> arbitraryPrimType ]
-
-arbitraryPrimType :: Gen DotProtoPrimType
-arbitraryPrimType = oneof [ elements [ Int32
-                                     , Int64
-                                     , SInt32
-                                     , SInt64
-                                     , UInt32
-                                     , UInt64
-                                     , Fixed32
-                                     , Fixed64
-                                     , SFixed32
-                                     , SFixed64
-                                     , String
-                                     , Bytes
-                                     , Bool
-                                     , Float
-                                     , Double
-                                     ]
-                          , Named <$> arbitrarySingleIdentifier
-                          ]
+arbitraryService = do
+  identifier <- arbitrarySingleIdentifier
+  parts      <- smallListOf arbitrary
+  return (DotProtoService identifier parts)
 
 arbitraryIdentifierName :: Gen String
-arbitraryIdentifierName = liftM2 (:) (elements $ ['a'..'z'] ++ ['A'..'Z'])
-                                     (smallListOf $ elements $ ['a'..'z'] ++ ['A'..'Z'] ++ ['_'])
+arbitraryIdentifierName = do
+  c  <- elements (['a'..'z'] ++ ['A'..'Z'])
+  cs <- smallListOf (elements (['a'..'z'] ++ ['A'..'Z'] ++ ['_']))
+  return (c:cs)
 
 arbitrarySingleIdentifier :: Gen DotProtoIdentifier
-arbitrarySingleIdentifier = Single <$> arbitraryIdentifierName
+arbitrarySingleIdentifier = fmap Single arbitraryIdentifierName
 
 arbitraryPathIdentifier :: Gen DotProtoIdentifier
-arbitraryPathIdentifier = Path <$> liftM2 (:) arbitraryIdentifierName (smallListOf1 arbitraryIdentifierName)
+arbitraryPathIdentifier = do
+  name  <- arbitraryIdentifierName
+  names <- smallListOf1 arbitraryIdentifierName
+  return (Path (name:names))
 
 arbitraryNestedIdentifier :: Gen DotProtoIdentifier
-arbitraryNestedIdentifier = Qualified <$> arbitraryIdentifier <*> arbitrarySingleIdentifier
+arbitraryNestedIdentifier = do
+  identifier0 <- arbitraryIdentifier
+  identifier1 <- arbitrarySingleIdentifier
+  return (Qualified identifier0 identifier1)
 
 -- these two kinds of identifiers are usually interchangeable, the others are not
 arbitraryIdentifier :: Gen DotProtoIdentifier
 arbitraryIdentifier = oneof [arbitrarySingleIdentifier, arbitraryPathIdentifier]
-
-arbitraryValue :: Gen DotProtoValue
-arbitraryValue = oneof [ Identifier <$> arbitrarySingleIdentifier
-                       , StringLit  <$> return "" -- arbitrary
-                       , IntLit     <$> arbitrary
-                       , FloatLit   <$> arbitrary
-                       , BoolLit    <$> arbitrary
-                       ]
-
-arbitraryFieldNumber :: Gen Int
-arbitraryFieldNumber = fromIntegral <$> (arbitrary :: Gen Natural)
 
 -- [note] quickcheck's default scaling generates *extremely* large asts past 20 iterations
 --        the parser is not particularly slow but it does have noticeable delay on megabyte-large .proto files


### PR DESCRIPTION
The `Proto3.Suite.DotProto.AST` module has several `arbitraryXXX`
functions at the bottom of the module which could be made into
`Arbitrary` instances for their respective types.  This change
refactors the module to create `Arbitrary` instances for as many
types as possible.

This refactor is behavior-preserving, meaning that some of these
`Arbitrary` instances are not as arbitrary as they could be.  For
example, some of the instances return fields that are always an
empty string when they could be arbitrary strings.  This is because
this was the original behavior of the corresponding `arbitraryXXX`
function.

I also try to avoid using operators as much as possible and use `do`
notation wherever possible.