### PR TITLE
Ensure CG tests succeed during `nix-build` and `nix-shell` via `cabal`

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -4,9 +4,10 @@
 #
 # ... then run `cabal` commands as you would normally do:
 #
-#     $ cabal configure
-#     $ cabal build
-#     $ cabal test
+#     [nix-shell]$ cabal configure --with-gcc=clang --enable-tests
+#     [nix-shell]$ cabal build
+#     [nix-shell]$ cabal test
+
 let
   config = {
     packageOverrides = pkgs:
@@ -66,8 +67,12 @@ let
         inherit (json) rev sha256;
       };
 
-  pkgs = import nixpkgs { inherit config; };
+   linuxPkgs = import nixpkgs { inherit config; system = "x86_64-linux" ; };
+  darwinPkgs = import nixpkgs { inherit config; system = "x86_64-darwin"; };
+        pkgs = import nixpkgs { inherit config; };
 
 in
-  { proto3-suite = pkgs.haskellPackages.proto3-suite;
+  { proto3-suite-linux  =  linuxPkgs.haskellPackages.proto3-suite;
+    proto3-suite-darwin = darwinPkgs.haskellPackages.proto3-suite;
+    proto3-suite        =       pkgs.haskellPackages.proto3-suite;
   }

--- a/tests/TestCodeGen.hs
+++ b/tests/TestCodeGen.hs
@@ -8,7 +8,6 @@ import           Control.Applicative
 import           Data.List
 import qualified Data.Text as T
 import           Data.String (IsString)
-import           Paths_proto3_suite (getDataFileName)
 import           Test.Tasty
 import           Test.Tasty.HUnit (Assertion, (@?=), (@=?), testCase, assertBool)
 import           Test.Tasty.QuickCheck (testProperty, (===))
@@ -50,9 +49,7 @@ simpleEncodeDotProto =
 
        compileTestDotProto
 
-       encodeScript <- getDataFileName "tests/encode.sh"
-       chmod executable (fromString encodeScript)
-       exitCode <- proc (T.pack encodeScript) [hsTmpDir] empty
+       exitCode <- proc "tests/encode.sh" [hsTmpDir] empty
        exitCode @?= ExitSuccess
 
        exitCode <- shell (T.concat ["protoc --python_out=", pyTmpDir, " test-files/test.proto"]) empty
@@ -81,9 +78,7 @@ simpleDecodeDotProto =
 
        compileTestDotProto
 
-       decodeScript <- getDataFileName "tests/decode.sh"
-       chmod executable (fromString decodeScript)
-       exitCode <- proc (T.pack decodeScript) [hsTmpDir] empty
+       exitCode <- proc "tests/decode.sh" [hsTmpDir] empty
        exitCode @?= ExitSuccess
 
        exitCode <- shell (T.concat ["protoc --python_out=", pyTmpDir, " test-files/test.proto"]) empty

--- a/tests/decode.sh
+++ b/tests/decode.sh
@@ -2,7 +2,7 @@
 
 hsTmpDir=$1
 
-stack ghc --                          \
+ghc                                   \
     --make                            \
     -odir $hsTmpDir                   \
     -hidir $hsTmpDir                  \

--- a/tests/encode.sh
+++ b/tests/encode.sh
@@ -2,7 +2,7 @@
 
 hsTmpDir=$1
 
-stack ghc --                          \
+ghc                                   \
     --make                            \
     -odir $hsTmpDir                   \
     -hidir $hsTmpDir                  \

--- a/tests/tests.patch
+++ b/tests/tests.patch
@@ -5,10 +5,10 @@ index 59ad7cc..d1df62b 100755
 @@ -1,8 +1,8 @@
 -#!/bin/bash -eu
 +#! @bash@/bin/bash -eu
- 
+
  hsTmpDir=$1
- 
--stack ghc --                          \
+
+-ghc                                   \
 +@ghc@/bin/ghc                         \
      --make                            \
      -odir $hsTmpDir                   \
@@ -20,10 +20,10 @@ index 8ebea7e..bc79de2 100755
 @@ -1,8 +1,8 @@
 -#!/bin/bash -eu
 +#! @bash@/bin/bash -eu
- 
+
  hsTmpDir=$1
- 
--stack ghc --                          \
+
+-ghc                                   \
 +@ghc@/bin/ghc                         \
      --make                            \
      -odir $hsTmpDir                   \


### PR DESCRIPTION
This PR fixes the way that code generation tests are run. The pattern is now the same as `grpc-haskell`: we use the custom `ghc` which has the `proto3-suite` and its dependencies included.

After this change, `nix-shell release.nix proto3-suite.env` produces an environment where all of the unittests can be run interactively and iteratively without any by-hand tweaking, which was not the case before.

Also adds `proto3-suite-linux` and `proto3-suite-darwin` toplevel attrs.