### PR TITLE
Increase upper bound of the 'vector' dependency.

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -37,7 +37,7 @@ library
                        safe ==0.3.*,
                        text >= 0.2 && <1.3,
                        transformers >=0.4 && <0.6,
-                       vector ==0.11.*
+                       vector >=0.11 && < 0.13
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
It's needed to build with stack nightly.