### PR TITLE
Use identical test values in python codec test scripts

### DIFF
--- a/tests/SimpleDecodeDotProto.hs
+++ b/tests/SimpleDecodeDotProto.hs
@@ -26,7 +26,9 @@ tests = testGroup "Decode protobuf messages from Python"
           [  testCase1,  testCase2,  testCase3,  testCase4
           ,  testCase5,  testCase6,  testCase7,  testCase8
           ,  testCase9, testCase10, testCase11, testCase12
-          , testCase13, testCase14, testCase15, testCase16 ]
+          , testCase13, testCase14, testCase15, testCase16
+          , allTestsDone -- this should always run last
+          ]
 
 readProto :: Message a => IO a
 readProto = do length <- readLn
@@ -65,7 +67,7 @@ testCase3  = testCase "Nested enumeration" $
 
 testCase4  = testCase "Nested message" $
     do WithNesting { withNestingNestedMessage = a } <- readProto
-       a @?= Just (WithNesting_Nested "testCase4 nestedField1" 0x1010)
+       a @?= Just (WithNesting_Nested "testCase4 nestedField1" 0xABCD)
 
        WithNesting { withNestingNestedMessage = b } <- readProto
        b @?= Nothing
@@ -75,7 +77,7 @@ testCase5  = testCase "Nested repeated message" $
        length a @?= 3
        let [a1, a2, a3] = a
 
-       a1 @?= WithNestingRepeated_Nested "testCase5 nestedField1" 0xDCBA [5, 3, 2, 1, 1] [0xBADBEEF, 0x40302001, 0xACBA, 3]
+       a1 @?= WithNestingRepeated_Nested "testCase5 nestedField1" 0xDCBA [1, 1, 2, 3, 5] [0xB, 0xABCD, 0xBADBEEF, 0x10203040]
        a2 @?= WithNestingRepeated_Nested "Hello world" 0x7FFFFFFF [0, 0, 0] []
        a3 @?= WithNestingRepeated_Nested "" 0 [] []
 
@@ -200,7 +202,7 @@ testCase13 = testCase "Nested message with the same name as another package-leve
 
 testCase14 = testCase "Qualified name resolution" $
     do WithQualifiedName { .. } <- readProto
-       withQualifiedNameQname1 @?= Just (ShadowedMessage "int value" 2)
+       withQualifiedNameQname1 @?= Just (ShadowedMessage "int value" 42)
        withQualifiedNameQname2 @?= Just (MessageShadower_ShadowedMessage "string value" "hello world")
 
 testCase15 = testCase "Imported message resolution" $
@@ -213,3 +215,7 @@ testCase16 = testCase "Proper resolution of shadowed message names" $
        usingImportedImportedNesting @?= Just (TestImport.WithNesting (Just (TestImport.WithNesting_Nested 1 2))
                                                                      (Just (TestImport.WithNesting_Nested 3 4)))
        usingImportedLocalNesting @?= Just (WithNesting (Just (WithNesting_Nested "field" 0xBEEF)))
+
+allTestsDone = testCase "Receive end of test suite sentinel message" $
+   do MultipleFields{..} <- readProto
+      multipleFieldsMultiFieldString @?= "All tests complete"

--- a/tests/SimpleEncodeDotProto.hs
+++ b/tests/SimpleEncodeDotProto.hs
@@ -15,7 +15,7 @@ outputMessage msg =
 
 testCase1 :: IO ()
 testCase1 =
-  let trivial = Trivial 0xBADBEEF
+  let trivial = Trivial 0x7BADBEEF
   in outputMessage trivial
 
 testCase2 :: IO ()
@@ -27,7 +27,7 @@ testCase3 =
   do outputMessage (WithEnum (Enumerated (Right WithEnum_TestEnumENUM1)))
      outputMessage (WithEnum (Enumerated (Right WithEnum_TestEnumENUM2)))
      outputMessage (WithEnum (Enumerated (Right WithEnum_TestEnumENUM3)))
-     outputMessage (WithEnum (Enumerated (Left 0xABABABAB)))
+     outputMessage (WithEnum (Enumerated (Left 0xBEEF)))
 
 testCase4 :: IO ()
 testCase4 =

--- a/tests/check_simple_dot_proto.py
+++ b/tests/check_simple_dot_proto.py
@@ -10,7 +10,7 @@ def read_proto(cls):
 
 # Test case 1: Trivial message
 case1 = read_proto(Trivial)
-assert case1.trivialField == 0xBADBEEF
+assert case1.trivialField == 0x7BADBEEF
 
 # Test case 2: Multiple fields
 case2 = read_proto(MultipleFields)
@@ -32,7 +32,7 @@ case3c = read_proto(WithEnum)
 assert case3c.enumField == WithEnum.ENUM3
 
 case3d = read_proto(WithEnum)
-assert case3d.enumField == 0xABABABAB
+assert case3d.enumField == 0xBEEF
 
 # Test case 4: Nested messages
 case4a = read_proto(WithNesting)

--- a/tests/send_simple_dot_proto.py
+++ b/tests/send_simple_dot_proto.py
@@ -32,15 +32,15 @@ write_proto(WithEnum(enumField = 0xBEEF))
 write_proto(
     WithNesting(nestedMessage=
                 WithNesting.Nested(nestedField1 = "testCase4 nestedField1",
-                                   nestedField2 = 0x1010)))
+                                   nestedField2 = 0xABCD)))
 write_proto(WithNesting())
 
 # Test case 5: Nested repeated message
 write_proto(WithNestingRepeated(nestedMessages =
     [ WithNestingRepeated.Nested(nestedField1 = "testCase5 nestedField1",
                                  nestedField2 = 0xDCBA,
-                                 nestedPacked = [5, 3, 2, 1, 1],
-                                 nestedUnpacked = [0xBADBEEF, 0x40302001, 0xACBA, 3]),
+                                 nestedPacked = [1, 1, 2, 3, 5],
+                                 nestedUnpacked = [0xB, 0xABCD, 0xBADBEEF, 0x10203040]),
       WithNestingRepeated.Nested(nestedField1 = "Hello world",
                                  nestedField2 = 0x7FFFFFFF,
                                  nestedPacked = [0, 0, 0],
@@ -144,7 +144,7 @@ write_proto(MessageShadower(shadowed_message = MessageShadower.ShadowedMessage(n
 write_proto(MessageShadower.ShadowedMessage(name = "another name", value = "another string"))
 
 # Test case 14: Qualified name resolution
-write_proto(WithQualifiedName(qname1 = ShadowedMessage(name="int value", value=2),
+write_proto(WithQualifiedName(qname1 = ShadowedMessage(name="int value", value=42),
                               qname2 = MessageShadower.ShadowedMessage(name="string value", value="hello world")))
 
 # Test case 15: Imported message resolution
@@ -154,3 +154,6 @@ write_proto(test_import.WithNesting(nestedMessage1 = test_import.WithNesting.Nes
 write_proto(UsingImported(importedNesting = test_import.WithNesting(nestedMessage1 = test_import.WithNesting.Nested(nestedField1 = 1, nestedField2 = 2),
                                                                     nestedMessage2 = test_import.WithNesting.Nested(nestedField1 = 3, nestedField2 = 4)),
                           localNesting = WithNesting(nestedMessage = WithNesting.Nested(nestedField1 = "field", nestedField2 = 0xBEEF))))
+
+# Send the special 'done' message
+write_proto(MultipleFields(multiFieldString = "All tests complete"))


### PR DESCRIPTION
This PR makes it so that, e.g.
```bash
[nix-shell]$ mkdir -p test-files/py-tmp
[nix-shell]$ export PYTHONPATH=$PYTHONPATH:$(pwd)/test-files/py-tmp
[nix-shell]$ protoc --python_out=test-files/py-tmp test-files/test.proto
[nix-shell]$ protoc --python_out=test-files/py-tmp test-files/test_import.proto
[nix-shell]$ touch test-files/py-tmp/test_files/__init__.py
[nix-shell]$ python tests/send_simple_dot_proto.py | python tests/check_simple_dot_proto.py
```
will succeed, whereas before only the haskell encoder => python decoder and python encoder => haskell decoder paths could be exercised.
