### PR TITLE
Add kind signature to `GenericMessage` type parameter for successful …

### DIFF
--- a/src/Proto3/Suite/Class.hs
+++ b/src/Proto3/Suite/Class.hs
@@ -546,7 +546,7 @@ message pr = DotProtoMessage (Single $ nameOf pr) $ DotProtoMessageField <$> (do
 
 -- * Generic Instances
 
-class GenericMessage f where
+class GenericMessage (f :: * -> *) where
   type GenericFieldCount f :: Nat
 
   genericEncodeMessage :: FieldNumber -> f a -> Encode.MessageBuilder
@@ -580,7 +580,7 @@ instance MessageField c => GenericMessage (K1 i c) where
   genericDotProto _ = [protoType (Proxy :: Proxy c)]
 
 instance (Selector s, GenericMessage f) => GenericMessage (M1 S s f) where
-  type GenericFieldCount (M1 S t f) = GenericFieldCount f
+  type GenericFieldCount (M1 S s f) = GenericFieldCount f
   genericEncodeMessage num (M1 x) = genericEncodeMessage num x
   genericDecodeMessage num = fmap M1 $ genericDecodeMessage num
   genericDotProto _ = map applyName $ genericDotProto (Proxy :: Proxy f)


### PR DESCRIPTION
…compilation under ghc 8.2.

This PR fixes a compilation bug under GHC 8.2. Without this kind signature, GHC is unable correctly to infer kind `k` for `newtype M1 i c (f :: k -> *) (p :: k) = M1 (f p)` in the context of our `GenericMessage` instance for `M1 S s f`. It can't, due to a combination of:

- Both `PolyKinds` and `DataKinds` being used
- The [new](https://ryanglscott.github.io/2017/04/12/improvements-to-deriving-in-ghc-82) poly-kinded `GHC.Generics` implementation
- The ambiguity of the `()` syntactic element

Hat-tip @Gabriel439 for the analysis.
